### PR TITLE
Trivy updates

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
-          --security-checks "{{input.security-checks}}" \
+          --security-checks "{{inputs.security-checks}}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Sarif template output path relative to repository root, if any (example: trivy-results.sarif)'
     required: false
     default: ''
+  security-checks:
+    description: 'Does not scan image for secrets, but only vulnerabilities'
+    required: false
+    default: vuln 
 
 runs:
   using: composite
@@ -61,5 +65,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
+          --security-checks "{{input.security-checks}}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   security-checks:
     description: 'Does not scan image for secrets, but only vulnerabilities'
     required: false
-    default: vuln 
+    default: vuln
 
 runs:
   using: composite
@@ -65,6 +65,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
-          --security-checks "{{ inputs.security-checks }}" \
+          --security-checks "${{ inputs.security-checks }}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
-          --security-checks "{{inputs.security-checks}}" \
+          --security-checks "{{ inputs.security-checks }}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"


### PR DESCRIPTION
This PR:

Adds `security-checks` flag to vuln to skip secret detection via Trivy.