### PR TITLE
[trivy] Trivy updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           image: gcr.io/distroless/static
           sarif: trivy-results.sarif
 
-      # - name: '[test] Upload scan results to GitHub Security tab'
-      #   uses: github/codeql-action/upload-sarif@v2
-      #   with:
-      #     sarif_file: trivy-results.sarif
+      - name: '[test] Upload scan results to GitHub Security tab'
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           image: gcr.io/distroless/static
           sarif: trivy-results.sarif
 
-      - name: '[test] Upload scan results to GitHub Security tab'
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: trivy-results.sarif
+      # - name: '[test] Upload scan results to GitHub Security tab'
+      #   uses: github/codeql-action/upload-sarif@v2
+      #   with:
+      #     sarif_file: trivy-results.sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,6 @@ jobs:
           sarif: trivy-results.sarif
 
       - name: '[test] Upload scan results to GitHub Security tab'
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,6 +34,6 @@ jobs:
           image: gcr.io/distroless/static
           sarif: trivy-results.sarif
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           image: gcr.io/distroless/static
           sarif: trivy-results.sarif
-      # - name: Upload Trivy scan results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@v2
-      #   with:
-      #     sarif_file: trivy-results.sarif
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           image: gcr.io/distroless/static
           sarif: trivy-results.sarif
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: trivy-results.sarif
+      # - name: Upload Trivy scan results to GitHub Security tab
+      #   uses: github/codeql-action/upload-sarif@v2
+      #   with:
+      #     sarif_file: trivy-results.sarif

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
-          --security-checks "{{input.security-checks}}" \
+          --security-checks "{{inputs.security-checks}}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: 'Sarif template output path relative to repository root, if any (example: trivy-results.sarif)'
     required: false
     default: ''
+  security-checks:
+    description: 'Does not scan image for secrets, but only vulnerabilities'
+    required: false
+    default: vuln 
 
 runs:
   using: composite
@@ -61,5 +65,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
+          --security-checks "{{input.security-checks}}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   security-checks:
     description: 'Does not scan image for secrets, but only vulnerabilities'
     required: false
-    default: vuln 
+    default: vuln
 
 runs:
   using: composite
@@ -65,6 +65,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
-          --security-checks "{{ inputs.security-checks }}" \
+          --security-checks "${{ inputs.security-checks }}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: 'Sarif template output path relative to repository root, if any (example: trivy-results.sarif)'
     required: false
     default: ''
-  security-checks:
+  scanners:
     description: 'Does not scan image for secrets, but only vulnerabilities'
     required: false
     default: vuln
@@ -115,6 +115,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
-          --security-checks "${{ inputs.security-checks }}" \
+          --scanners "${{ inputs.scanners }}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,6 @@ runs:
         fi
 
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro -v "${{ github.workspace }}:/workspace" aquasec/trivy image \
-          --security-checks "{{inputs.security-checks}}" \
+          --security-checks "{{ inputs.security-checks }}" \
           --vuln-type "${{ inputs.type }}" --severity "${{ inputs.severities }}" \
           --ignore-unfixed --no-progress --timeout 10m ${opt_args} "${IMAGE}"


### PR DESCRIPTION
This PR:
- Replaces `--security-checks` with `--scanners`, since the latter is deprecated
- Uptades `codeql` from `v1` to `v2`