### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: Action tests
+permissions:
+  contents: read
+  security-events: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/broadinstitute/dsp-appsec-trivy-action/security/code-scanning/21](https://github.com/broadinstitute/dsp-appsec-trivy-action/security/code-scanning/21)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, the following permissions are necessary:
- `contents: read` to allow the workflow to read repository contents.
- `security-events: write` to upload SARIF files to the GitHub Security tab.

This ensures that the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
