### PR TITLE
bump actions/checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test Trivy action
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: '[test] Build & scan'
         uses: ./

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -7,7 +7,7 @@ jobs:
     name: DSP AppSec Trivy check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       # simple case
       - uses: broadinstitute/dsp-appsec-trivy-action@v1


### PR DESCRIPTION
v4 is better than v2 but doesn't force use of node24 runners as does v5 or v6.