### PR TITLE
update to debian image that is used by other services

### DIFF
--- a/test/Dockerfile.blessed
+++ b/test/Dockerfile.blessed
@@ -1,5 +1,5 @@
 FROM scratch
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-alpine
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
 RUN echo Test

--- a/test/Dockerfile.notrivy
+++ b/test/Dockerfile.notrivy
@@ -1,5 +1,5 @@
 FROM scratch
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-alpine
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
 RUN exit 1


### PR DESCRIPTION
As part of a clean up of blessed images, changing the test image to one that is used by other services, allowing us to remove 17-alpine from the list of maintained images. 